### PR TITLE
Really use python version specified in runtime.txt to bootstrap buildout

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -60,6 +60,17 @@ fi
 cd $BUILD_DIR
 echo "-----> Init buildout"
 curl -OL "${BOOTSTRAP_PY_URL}"
+if [ -f "$BUILD_DIR/.heroku/python/bin/python" ]; then
+    # If heroku-buildpack-python was used before, set environement variables to find the python that was specified in runtime.txt
+    export PATH=$BUILD_DIR/.heroku/python/bin:$BUILD_DIR/.heroku/vendor/bin:$PATH
+    export PYTHONUNBUFFERED=1
+    export LANG=en_US.UTF-8
+    export C_INCLUDE_PATH=/app/.heroku/vendor/include:$BUILD_DIR/.heroku/vendor/include:/app/.heroku/python/include
+    export CPLUS_INCLUDE_PATH=/app/.heroku/vendor/include:$BUILD_DIR/.heroku/vendor/include:/app/.heroku/python/include
+    export LIBRARY_PATH=/app/.heroku/vendor/lib:$BUILD_DIR/.heroku/vendor/lib:/app/.heroku/python/lib:$BUILD_DIR/.heroku/python/lib
+    export LD_LIBRARY_PATH=/app/.heroku/vendor/lib:$BUILD_DIR/.heroku/vendor/lib:/app/.heroku/python/lib:$BUILD_DIR/.heroku/python/lib
+    export PKG_CONFIG_PATH=/app/.heroku/vendor/lib/pkg-config:$BUILD_DIR/.heroku/vendor/lib/pkg-config:/app/.heroku/python/lib/pkg-config
+fi
 python bootstrap.py -c $BUILDOUT_CFG
 echo "-----> Run bin/buildout -c ${BUILDOUT_CFG} ${BUILDOUT_VERBOSITY}"
 bin/buildout -c $BUILDOUT_CFG $BUILDOUT_VERBOSITY


### PR DESCRIPTION
Really use python version specified in runtime.txt to bootstrap buildout and set variables for egg compilation like PyYAML.
Previously, it always used python 2.7 from ubuntu, not the downloaded python from the python buildpack.